### PR TITLE
Fix enabled routes query

### DIFF
--- a/gateway-server/src/main/java/com/dcits/saas/gateway/dao/repository/GatewayRouteRepository.java
+++ b/gateway-server/src/main/java/com/dcits/saas/gateway/dao/repository/GatewayRouteRepository.java
@@ -14,8 +14,9 @@ import reactor.core.publisher.Mono;
 @Repository
 public interface GatewayRouteRepository extends R2dbcRepository<RouteDO, Long> {
 
-	@Query("select * from gateway_route where enable_flag = 1")
-	Flux<RouteDO> findAllEnabled();
+    // Wrong column name will lead to empty results.
+    @Query("select * from gateway_route where is_enabled = 1")
+    Flux<RouteDO> findAllEnabled();
 
 	@Query("update gateway_route set is_enabled = :isEnabled where route_id = :id")
 	Mono<Long> updateStatus(Long id, boolean isEnabled);


### PR DESCRIPTION
## Summary
- correct the query in `GatewayRouteRepository` to use the proper `is_enabled` column

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6870d2f44698832c8255e4e484f124a3