### PR TITLE
Update dependencies for Spring Boot 3.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-### 基于springboot3, spring-cloud, jdk17实现通过Redis动态刷新route的网关
+### 基于Spring Boot 3.5.3、Spring Cloud 2024、JDK17实现通过Redis动态刷新route的网关

--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -48,11 +48,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-r2dbc</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>io.asyncer</groupId>
-			<artifactId>r2dbc-mysql</artifactId>
-			<version>1.0.5</version>
-		</dependency>
+                <dependency>
+                        <groupId>io.asyncer</groupId>
+                        <artifactId>r2dbc-mysql</artifactId>
+                        <version>1.0.6</version>
+                </dependency>
 
 		<!-- jackson -->
 		<dependency>
@@ -68,11 +68,11 @@
 			<artifactId>jackson-annotations</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.12.0</version>
-		</dependency>
+                <dependency>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                        <version>3.13.0</version>
+                </dependency>
 
 		<dependency>
 			<groupId>cn.hutool</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,12 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<spring-boot.version>3.1.5</spring-boot.version>
-		<spring-cloud.version>2022.0.4</spring-cloud.version>
-		<spring-cloud-alibaba.version>2022.0.0.0</spring-cloud-alibaba.version>
-		<jackson.version>2.15.2</jackson.version>
+                <spring-boot.version>3.5.3</spring-boot.version>
+                <!-- Spring Cloud 2024.x line is compatible with Spring Boot 3.5 -->
+                <spring-cloud.version>2024.0.0</spring-cloud.version>
+                <!-- Use the matching Spring Cloud Alibaba release -->
+                <spring-cloud-alibaba.version>2024.0.0.0</spring-cloud-alibaba.version>
+                <jackson.version>2.17.0</jackson.version>
 	</properties>
 
 	<dependencyManagement>
@@ -89,12 +91,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.3.1</version>
+                                        <version>3.3.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
-					<version>3.3.0</version>
+                                        <version>3.3.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.springframework.boot</groupId>
@@ -108,7 +110,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
+                                <version>3.11.1</version>
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>


### PR DESCRIPTION
## Summary
- bump Spring Boot to 3.5.3
- update Spring Cloud and Spring Cloud Alibaba versions
- bump Jackson, r2dbc-mysql and commons-lang3
- upgrade Maven plugin versions
- document new versions in README

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6870d83f0d58832cb63be1c0473ddfe6